### PR TITLE
fix: increase right padding

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -57,7 +57,7 @@
   border-radius: var(--auro-border-radius);
   padding: var(--auro-size-xs);
   padding-left: var(--auro-size-sm);
-  padding-right: var(--auro-size-xs);
+  padding-right: var(--auro-size-md);
 
   border-color: var(--auro-color-base-neutral-400);
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

Per @sryckman, increase the right padding of the alert component to 1rem.

Before:
![image](https://user-images.githubusercontent.com/4992896/95138591-739d4780-071f-11eb-8a55-325c1fb7c399.png)

After:
![image](https://user-images.githubusercontent.com/4992896/95138652-97f92400-071f-11eb-8242-f3f8891a129c.png)

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
